### PR TITLE
Add old index expiration cron job

### DIFF
--- a/deployment/roles/elasticsearch/tasks/main.yml
+++ b/deployment/roles/elasticsearch/tasks/main.yml
@@ -86,3 +86,44 @@
   systemd:
     name: "{{ systemd_service_name }}"
     state: restarted
+
+- name: Add Elastic PGP key
+  become: yes
+  apt_key:
+    url: https://packages.elastic.co/GPG-KEY-elasticsearch
+    state: present
+
+- name: Add Elastic APT repository
+  become: yes
+  apt_repository:
+    repo: "deb [arch=amd64] https://packages.elastic.co/curator/5/debian stable main"
+    state: present
+    update_cache: yes
+
+- name: Install Curator package
+  become: yes
+  apt:
+    name: elasticsearch-curator
+
+- name: Install cron package
+  become: yes
+  apt:
+    name: anacron
+
+- name: Render Curator config file
+  template:
+    src: curator.yml
+    dest: "{{ runtime_dir }}/"
+
+- name: Install Curator cron job
+  become: yes
+  template:
+    src: expire-indexes
+    dest: /etc/cron.daily/
+    mode: u+x,g+x,o+x
+
+- name: Reload cron server to pick up new cron job
+  become: yes
+  systemd:
+    name: cron
+    state: restarted

--- a/deployment/roles/elasticsearch/templates/curator.yml
+++ b/deployment/roles/elasticsearch/templates/curator.yml
@@ -1,0 +1,22 @@
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+client:
+  hosts:
+    - 127.0.0.1
+  port: 9200
+  url_prefix:
+  use_ssl: False
+  certificate:
+  client_cert:
+  client_key:
+  ssl_no_validate: False
+  http_auth:
+  timeout: 30
+  master_only: False
+
+logging:
+  loglevel: INFO
+  logfile:
+  logformat: default
+  blacklist: ['elasticsearch', 'urllib3']

--- a/deployment/roles/elasticsearch/templates/expire-indexes
+++ b/deployment/roles/elasticsearch/templates/expire-indexes
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+main () {
+    curator --config="{{ runtime_dir }}/curator.yml" "{{ runtime_dir }}/runtime/elasticsearch/curator-action-expire-indexes.yml"
+}
+
+
+main "$@"

--- a/runtime/elasticsearch/curator-action-expire-indexes.yml
+++ b/runtime/elasticsearch/curator-action-expire-indexes.yml
@@ -1,0 +1,27 @@
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+#
+# Also remember that all examples have 'disable_action' set to True.  If you
+# want to use this action as a template, be sure to set this to False after
+# copying it.
+actions:
+  1:
+    action: delete_indices
+    description: >-
+      Delete indices older than 45 days (based on index name), for logstash-
+      prefixed indices. Ignore the error if the filter does not result in an
+      actionable list of indices (ignore_empty_list) and exit cleanly.
+    options:
+      ignore_empty_list: True
+      disable_action: False
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+    - filtertype: age
+      source: name
+      direction: older
+      timestring: '%Y.%m.%d'
+      unit: days
+      unit_count: 45


### PR DESCRIPTION
Deletes Elasticsearch indexes older than 45 days.

https://rchain.atlassian.net/browse/RCHAIN-3700